### PR TITLE
Fix uppercase indigo in pt-BR

### DIFF
--- a/lib/locales/pt-BR.yml
+++ b/lib/locales/pt-BR.yml
@@ -94,7 +94,7 @@ pt-BR:
       prefix: ["Sr.", "Sra.", "Srta.", "Dr.", "Dra."]
       suffix: ["Jr.", "Neto", "Filho"]
     color:
-      name: ["Abóbora", "Amaranto", "Amarelo", "Âmbar", "Ameixa", "Ardósia", "Azul", "Azul-bebê", "Azul-claro", "Azul-cobalto", "Azul-esverdeado", "Azul-marinho", "Azul-persa", "Azul-violeta", "Bege", "Branco", "Carmesim", "Carmim", "Cereja", "Cerúleo", "Champagne", "Chocolate", "Cinza", "Coral", "Escarlate", "Framboesa", "índigo", "Laranja", "Lavanda", "Lilás", "Lima", "Magenta", "Marfim", "Marrom", "Oliva", "Ouro", "Pêssego", "Prata", "Preto", "Rosa", "rosa-arroxeado", "Rosa-magenta", "Roxo", "Salmão", "Turquesa", "Uva", "Verde", "Verde-água", "Verde-claro", "Verde-jade", "Verde-limão", "Verde-primavera", "Vermelho", "Violeta"]
+      name: ["Abóbora", "Amaranto", "Amarelo", "Âmbar", "Ameixa", "Ardósia", "Azul", "Azul-bebê", "Azul-claro", "Azul-cobalto", "Azul-esverdeado", "Azul-marinho", "Azul-persa", "Azul-violeta", "Bege", "Branco", "Carmesim", "Carmim", "Cereja", "Cerúleo", "Champagne", "Chocolate", "Cinza", "Coral", "Escarlate", "Framboesa", "Índigo", "Laranja", "Lavanda", "Lilás", "Lima", "Magenta", "Marfim", "Marrom", "Oliva", "Ouro", "Pêssego", "Prata", "Preto", "Rosa", "rosa-arroxeado", "Rosa-magenta", "Roxo", "Salmão", "Turquesa", "Uva", "Verde", "Verde-água", "Verde-claro", "Verde-jade", "Verde-limão", "Verde-primavera", "Vermelho", "Violeta"]
     team:
       main_teams: ['Flamengo', 'Fluminense', 'Botafogo', 'Vasco da Gama', 'Corinthians','Grêmio','Flamengo','Palmeiras','Santos','Coritiba','Cruzeiro','Ponte Preta', 'Chapecoense', 'Sport','São Paulo','Bahia', 'Vitória', 'Avaí', 'América']
       prefix: ['Grêmio', 'Atlético', 'Clube de Regatas', 'Esporte']


### PR DESCRIPTION
Indigo, as opposed to the other color names, was spelled with a leader lower case letter. This Pull Request is meant to fix it.